### PR TITLE
Fix/runtime permissions remap

### DIFF
--- a/.github/actions/system-tests/action.yml
+++ b/.github/actions/system-tests/action.yml
@@ -37,6 +37,7 @@ runs:
     - name: Run tests
       run: |
         docker run --rm \
+          --user="$(id -u):$(id -g)" \
           -e SYSTEM_TEST_GITLAB_ACCESS_TOKEN="${{ inputs.system_test_gitlab_access_token }}" \
           -e SYSTEM_TEST_GITHUB_ACCESS_TOKEN="${{ inputs.system_test_github_access_token }}" \
           -e BOT_TEST_TEAMS_WEBHOOK_URL_GENERAL="${{ inputs.bot_test_teams_webhook_url_general }}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 ENV POETRY_VIRTUALENVS_CREATE=false
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y libnss-wrapper \
     # prepare dependencies for asdf
     curl git wget software-properties-common gnupg2 apt-transport-https \
     # asdf-nodejs
@@ -96,6 +96,9 @@ COPY splat/utils/aggregate_summaries.py aggregate_summaries.py
 RUN chmod +x bin/splat \
     && ln -s /splat/bin/splat /usr/local/bin/splat
 
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 RUN useradd -d /splat -u 1000 splatuser && \
     chown -R splatuser:splatuser /splat\
     && chmod -R a+rwX /splat
@@ -110,3 +113,4 @@ ENV PATH="/usr/local/bin:$ASDF_DATA_DIR/shims:/splat/bin/:$PATH" \
     # Allow "splat" to be used as a python module (there is a folder /splat/splat/):
     PYTHONPATH="/splat/"
 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ ENV PIPENV_IGNORE_VIRTUALENVS=1
 
 # === poetry ===
 ENV POETRY_VERSION=2.0.1
-ENV POETRY_HOME="/splat/.poetry"
 # When calling "poetry" while running in a virtual environment,
 # use the virtual environment from the project folder instead of the active one:
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
@@ -59,45 +58,55 @@ RUN apt-get install -y \
     python3.13 python3.13-venv \
     python3-pip
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/yarnkey.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+RUN pip3 install --break-system-packages \
+    poetry==$POETRY_VERSION \
+    pipenv \
+    uv
+
+# === yarn ===
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg \
+    | gpg --dearmor -o /usr/share/keyrings/yarnkey.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian/ stable main" \
+    | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y yarn
 
+# === asdf-cli ===
 RUN curl -LO https://github.com/asdf-vm/asdf/releases/download/v0.16.7/asdf-v0.16.7-linux-amd64.tar.gz \
     && tar -C /usr/local/bin -xzf asdf-v0.16.7-linux-amd64.tar.gz \
     && rm asdf-v0.16.7-linux-amd64.tar.gz \
     && chmod +x /usr/local/bin/asdf
 
-WORKDIR /splat/
-RUN useradd -d /splat -u 1001 splatuser && \
-    chown -R splatuser:splatuser /splat
-USER splatuser
-
-
-ENV PATH="$POETRY_HOME/bin:$ASDF_DATA_DIR/bin:$ASDF_DATA_DIR/shims:/splat/bin/:/splat/.local/bin:$PATH"
-
-RUN asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git && \
+# === Node.js via asdf (global) ===
+RUN mkdir -p /splat/.asdf && \
+    asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git && \
     asdf install nodejs 20.11.0 && \
     asdf set --home nodejs 20.11.0
 
-RUN pip install --user pipx --break-system-packages && \
-    pipx install poetry==$POETRY_VERSION pipenv uv
-
-COPY --chown=splatuser:splatuser pyproject.toml poetry.lock ./
-RUN poetry self add poetry-plugin-export && \
+# === Splat deps install globally ===
+WORKDIR /splat/
+COPY pyproject.toml poetry.lock ./
+RUN pip install poetry-plugin-export==1.9.0 --break-system-packages && \
     poetry export -f requirements.txt --output requirements.txt --without-hashes && \
     pip install -r requirements.txt --break-system-packages
 
-# Allow virtual env creation for cloned projects
-ENV POETRY_VIRTUALENVS_CREATE=true
+COPY splat/ splat/
+COPY bin/splat bin/splat
+COPY splat/utils/aggregate_summaries.py aggregate_summaries.py
+RUN chmod +x bin/splat \
+    && ln -s /splat/bin/splat /usr/local/bin/splat
 
-# Don't try to symlink dependencies:
-ENV UV_LINK_MODE=copy
+RUN useradd -d /splat -u 1000 splatuser && \
+    chown -R splatuser:splatuser /splat\
+    && chmod -R a+rwX /splat
+USER splatuser
 
-COPY --chown=splatuser splat/ splat/
-COPY --chown=splatuser bin/splat bin/splat
-COPY --chown=splatuser splat/utils/aggregate_summaries.py aggregate_summaries.py
+# === runtime envs ===
+ENV PATH="/usr/local/bin:$ASDF_DATA_DIR/shims:/splat/bin/:$PATH" \
+    # Allow virtual env creation for cloned projects
+    POETRY_VIRTUALENVS_CREATE=true \
+    # Don't try to symlink dependencies:
+    UV_LINK_MODE=copy \
+    # Allow "splat" to be used as a python module (there is a folder /splat/splat/):
+    PYTHONPATH="/splat/"
 
-# Allow "splat" to be used as a python module (there is a folder /splat/splat/):
-ENV PYTHONPATH="/splat/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,10 +99,18 @@ RUN chmod +x bin/splat \
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-RUN useradd -d /splat -u 1000 splatuser && \
-    chown -R splatuser:splatuser /splat\
-    && chmod -R a+rwX /splat
+RUN groupadd --gid 1000 splatuser \
+    && useradd --uid 1000 --gid splatuser \
+    --home-dir /home/splatuser --create-home --shell /bin/sh splatuser
+
+RUN chown -R splatuser:splatuser /splat && \
+    chmod -R a+rwX /splat
+
+RUN mkdir -p /home/hostuser \
+    && chmod a+rwX /home/hostuser
+
 USER splatuser
+ENV HOME=/home/splatuser
 
 # === runtime envs ===
 ENV PATH="/usr/local/bin:$ASDF_DATA_DIR/shims:/splat/bin/:$PATH" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,25 +63,20 @@ RUN pip3 install --break-system-packages \
     pipenv \
     uv
 
+
+# === node.js (v20.x) ===
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs
+
 # === yarn ===
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg \
     | gpg --dearmor -o /usr/share/keyrings/yarnkey.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian/ stable main" \
     | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
-    apt-get install -y yarn
+    apt-get install -y yarn \
+    && rm -rf /var/lib/apt/lists/*
 
-# === asdf-cli ===
-RUN curl -LO https://github.com/asdf-vm/asdf/releases/download/v0.16.7/asdf-v0.16.7-linux-amd64.tar.gz \
-    && tar -C /usr/local/bin -xzf asdf-v0.16.7-linux-amd64.tar.gz \
-    && rm asdf-v0.16.7-linux-amd64.tar.gz \
-    && chmod +x /usr/local/bin/asdf
-
-# === Node.js via asdf (global) ===
-RUN mkdir -p /splat/.asdf && \
-    asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git && \
-    asdf install nodejs 20.11.0 && \
-    asdf set --home nodejs 20.11.0
 
 # === Splat deps install globally ===
 WORKDIR /splat/

--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ package_managers:
 
 #### Run splat
 
+* The container’s default user is UID 1000; override with --user="$(id -u):$(id -g)" if your host UID/GID differs.
+
 ```bash
 docker run \
   --pull=always \
   -it \
-  -v <path-to-you-repository>:/home/splatuser/test-drive/ \
+  --user="$(id -u):$(id -g)" \
+  -v <path-to-you-repository>:/splat/test-drive/ \
   -v $(pwd)/splat.yaml:/splat/splat.yaml \
   girade/splat:1 \
   splat \

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker run \
   --pull=always \
   -it \
   --user="$(id -u):$(id -g)" \
-  -v <path-to-you-repository>:/splat/test-drive/ \
+  -v <path-to-your-repository>:/splat/test-drive/ \
   -v $(pwd)/splat.yaml:/splat/splat.yaml \
   girade/splat:1 \
   splat \

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -11,6 +11,10 @@ if [ "$HOST_UID" != "$SPLAT_UID" ]; then
   # set up a real home directory for hostuser
   export HOME=/home/hostuser
 
+  # - running container with --user=$(id -u):$(id -g) doesn’t add that UID/GID to /etc/passwd or /etc/group
+  # - causes getpwuid()/getgrgid() calls to fail in Git, pipenv, Python’s pwd module, etc.
+  # - solution: preload libnss_wrapper: intercepts NSS calls via LD_PRELOAD and reads from temp passwd/group files,
+  #   faking a hostuser/hostgroup entry so getpwuid()/getgrgid() work without touching system files
   PASSWD=/tmp/passwd
   GROUP=/tmp/group
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,6 +8,9 @@ SPLAT_UID=$(getent passwd splatuser | cut -d: -f3) # 1000 by default
 
 # only if host and splatuser UID missmatch
 if [ "$HOST_UID" != "$SPLAT_UID" ]; then
+  # set up a real home directory for hostuser
+  export HOME=/home/hostuser
+
   PASSWD=/tmp/passwd
   GROUP=/tmp/group
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# detect runtime host UID/GID
+HOST_UID=$(id -u)
+HOST_GID=$(id -g)
+SPLAT_UID=$(getent passwd splatuser | cut -d: -f3) # 1000 by default
+
+# only if host and splatuser UID missmatch
+if [ "$HOST_UID" != "$SPLAT_UID" ]; then
+  PASSWD=/tmp/passwd
+  GROUP=/tmp/group
+
+  cp /etc/passwd "$PASSWD"
+  cp /etc/group  "$GROUP"
+  echo "hostuser:x:${HOST_UID}:${HOST_GID}::/home/hostuser:/bin/sh" >> "$PASSWD"
+  echo "hostgroup:x:${HOST_GID}:" >> "$GROUP"
+
+  export NSS_WRAPPER_PASSWD="$PASSWD"
+  export NSS_WRAPPER_GROUP="$GROUP"
+  export LD_PRELOAD="libnss_wrapper.so"
+fi
+
+exec "$@"

--- a/splat/package_managers/pipenv/command_runner.py
+++ b/splat/package_managers/pipenv/command_runner.py
@@ -13,7 +13,7 @@ class PipenvCommandRunner:
 
     def install(self, cwd: Path) -> None:
         result = self.runner.run(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["install", "--dev"],
             cwd=cwd,
         )
@@ -21,7 +21,7 @@ class PipenvCommandRunner:
 
     def install_pip_audit(self, cwd: Path) -> None:
         result = self.runner.run(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["install", "pip-audit", "--dev"],
             cwd=cwd,
         )
@@ -31,7 +31,7 @@ class PipenvCommandRunner:
         """Generates requirements.txt for pipenv projects based on the package manager."""
         requirements_file_path = cwd / "requirements.txt"
         result = self.runner.run(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["requirements", "--dev"],
             cwd=cwd,
         )
@@ -39,7 +39,7 @@ class PipenvCommandRunner:
 
     def run_pip_freeze(self, cwd: Path) -> str:
         result = self.runner.run(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["run", "pip", "freeze"],
             cwd=cwd,
         )
@@ -47,7 +47,7 @@ class PipenvCommandRunner:
 
     def run_pip_audit(self, cwd: Path) -> str:
         result = self.runner.run(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             cwd=cwd,
             allowed_return_codes=[1],
@@ -61,7 +61,7 @@ class PipenvCommandRunner:
         args.append(f"{dep_name}=={dep_version}")
 
         result = self.runner.run(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=args,
             cwd=cwd,
         )
@@ -69,7 +69,7 @@ class PipenvCommandRunner:
 
     def graph(self, cwd: Path) -> str:
         result = self.runner.run(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["graph", "--json"],
             cwd=cwd,
         )
@@ -77,7 +77,7 @@ class PipenvCommandRunner:
 
     def update(self, cwd: Path) -> None:
         result = self.runner.run(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["update", "--dev"],
             cwd=cwd,
         )

--- a/splat/package_managers/poetry/command_runner.py
+++ b/splat/package_managers/poetry/command_runner.py
@@ -15,7 +15,7 @@ class PoetryCommandRunner:
     def env_use(self, python_version: str, cwd: Path) -> None:
         python_version_full_path = f"/usr/bin/{python_version}"
         result = self.runner.run(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["env", "use", python_version_full_path],
             cwd=cwd,
         )
@@ -23,7 +23,7 @@ class PoetryCommandRunner:
 
     def sync(self, cwd: Path) -> None:
         result = self.runner.run(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["sync", "--all-groups"],
             cwd=cwd,
         )
@@ -32,7 +32,7 @@ class PoetryCommandRunner:
     def export(self, cwd: Path) -> None:
         requirements_file_path = cwd / "requirements.txt"
         result = self.runner.run(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["export", "--without-hashes", "--all-groups"],
             cwd=cwd,
         )
@@ -40,7 +40,7 @@ class PoetryCommandRunner:
 
     def run_pip_audit(self, cwd: Path) -> str:
         result = self.runner.run(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             cwd=cwd,
             allowed_return_codes=[1],
@@ -56,7 +56,7 @@ class PoetryCommandRunner:
         else:
             args.append(f"{dep_name}@^{dep_version}")
         result = self.runner.run(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=args,
             cwd=cwd,
         )
@@ -64,7 +64,7 @@ class PoetryCommandRunner:
 
     def lock(self, cwd: Path) -> None:
         result = self.runner.run(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["lock", "--no-update"],
             cwd=cwd,
         )

--- a/splat/package_managers/uv/command_runner.py
+++ b/splat/package_managers/uv/command_runner.py
@@ -12,7 +12,7 @@ class UvCommandRunner:
 
     def sync(self, cwd: Path) -> None:
         result = self.runner.run(
-            cmd="/splat/.local/bin/uv",
+            cmd="/usr/local/bin/uv",
             args=["sync", "--dev"],
             cwd=cwd,
         )
@@ -20,14 +20,14 @@ class UvCommandRunner:
 
     def export(self, cwd: Path) -> None:
         self.runner.run(
-            cmd="/splat/.local/bin/uv",
+            cmd="/usr/local/bin/uv",
             args=["export", "--no-emit-project", "--dev", "--no-hashes", "-o", "requirements.txt"],
             cwd=cwd,
         )
 
     def run_pip_audit(self, cwd: Path) -> str:
         result = self.runner.run(
-            cmd="/splat/.local/bin/uv",
+            cmd="/usr/local/bin/uv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             cwd=cwd,
             allowed_return_codes=[1],
@@ -43,7 +43,7 @@ class UvCommandRunner:
         else:
             args.append(f"{dep_name}~={dep_version}")
         result = self.runner.run(
-            cmd="/splat/.local/bin/uv",
+            cmd="/usr/local/bin/uv",
             args=args,
             cwd=cwd,
         )
@@ -51,7 +51,7 @@ class UvCommandRunner:
 
     def upgrade(self, dep_name: str, dep_version: str, cwd: Path, is_dev: bool) -> None:
         result = self.runner.run(
-            cmd="/splat/.local/bin/uv",
+            cmd="/usr/local/bin/uv",
             args=["lock", "--upgrade-package", f"{dep_name}~={dep_version}"],
             cwd=cwd,
         )

--- a/splat/utils/command_runner/safe_run.py
+++ b/splat/utils/command_runner/safe_run.py
@@ -1,11 +1,11 @@
 from typing import Literal, cast
 
 COMMAND_WHITELIST = Literal[
-    "/splat/.local/bin/pipenv", "/usr/bin/yarn", "/splat/.local/bin/poetry", "/usr/bin/git", "/splat/.local/bin/uv"
+    "/usr/local/bin/pipenv", "/usr/bin/yarn", "/usr/local/bin/poetry", "/usr/bin/git", "/usr/local/bin/uv"
 ]
 
 COMMAND_ARGS_WHITELIST: dict[COMMAND_WHITELIST, list[tuple[str, ...]]] = {
-    "/splat/.local/bin/pipenv": [
+    "/usr/local/bin/pipenv": [
         ("install",),
         ("requirements",),
         ("run", "pip", "freeze"),
@@ -16,7 +16,7 @@ COMMAND_ARGS_WHITELIST: dict[COMMAND_WHITELIST, list[tuple[str, ...]]] = {
         ("update",),
     ],
     "/usr/bin/yarn": [("install",), ("audit",), ("upgrade",)],
-    "/splat/.local/bin/poetry": [
+    "/usr/local/bin/poetry": [
         ("sync",),
         ("export",),
         ("add",),
@@ -26,7 +26,7 @@ COMMAND_ARGS_WHITELIST: dict[COMMAND_WHITELIST, list[tuple[str, ...]]] = {
         ("env", "use"),
     ],
     "/usr/bin/git": [("check-ignore",)],
-    "/splat/.local/bin/uv": [
+    "/usr/local/bin/uv": [
         ("sync",),
         ("export",),
         ("run", "pip-audit"),

--- a/tests/package_managers/pipenv/test_pipenv_audit.py
+++ b/tests/package_managers/pipenv/test_pipenv_audit.py
@@ -17,7 +17,7 @@ class TestPipenvAudit(BasePackageManagerTest):
 
     def test_pipenv_audit_installs_dependencies_runs_pip_audit_no_vulns(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_no_vulns, stderr=""),
         )
@@ -25,11 +25,11 @@ class TestPipenvAudit(BasePackageManagerTest):
         result = self.pipenv_manager.audit(self.lockfile, re_audit=False)
         # assert
         self.assertTrue(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/pipenv", args=["requirements", "--dev"])
+            self.mock_command_runner.has_called(cmd="/usr/local/bin/pipenv", args=["requirements", "--dev"])
         )
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/pipenv",
+                cmd="/usr/local/bin/pipenv",
                 args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             )
         )
@@ -37,7 +37,7 @@ class TestPipenvAudit(BasePackageManagerTest):
 
     def test_pipenv_audit_runs_pip_audit_returns_vulns(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_with_vulns, stderr=""),
         )
@@ -48,7 +48,7 @@ class TestPipenvAudit(BasePackageManagerTest):
     def test_pipenv_audit_handles_audit_command_failure(self) -> None:
         # Setup audit command to simulate failure (non-zero exit code).
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=2, stdout="", stderr="error"),
         )
@@ -58,7 +58,7 @@ class TestPipenvAudit(BasePackageManagerTest):
 
     def test_pipenv_audit_with_re_audit_skips_install(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/pipenv",
+            cmd="/usr/local/bin/pipenv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_no_vulns, stderr=""),
         )
@@ -67,12 +67,12 @@ class TestPipenvAudit(BasePackageManagerTest):
 
         # Verify that install steps are skipped.
         self.assertFalse(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/pipenv", args=["install", "pip-audit", "--dev"])
+            self.mock_command_runner.has_called(cmd="/usr/local/bin/pipenv", args=["install", "pip-audit", "--dev"])
         )
         self.assertFalse(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/pipenv", args=["run", "pip", "freeze"])
+            self.mock_command_runner.has_called(cmd="/usr/local/bin/pipenv", args=["run", "pip", "freeze"])
         )
         # Requirements command should still be executed.
         self.assertTrue(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/pipenv", args=["requirements", "--dev"])
+            self.mock_command_runner.has_called(cmd="/usr/local/bin/pipenv", args=["requirements", "--dev"])
         )

--- a/tests/package_managers/pipenv/test_pipenv_update.py
+++ b/tests/package_managers/pipenv/test_pipenv_update.py
@@ -23,13 +23,11 @@ class TestPipenvUpdate(BasePackageManagerTest):
 
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/pipenv", args=["upgrade", "--ignore-pipfile", "package1==2.0.0"]
+                cmd="/usr/local/bin/pipenv", args=["upgrade", "--ignore-pipfile", "package1==2.0.0"]
             )
         )
-        self.assertTrue(self.mock_command_runner.has_called(cmd="/splat/.local/bin/pipenv", args=["update", "--dev"]))
-        self.assertTrue(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/pipenv", args=["run", "pip", "freeze"])
-        )
+        self.assertTrue(self.mock_command_runner.has_called(cmd="/usr/local/bin/pipenv", args=["update", "--dev"]))
+        self.assertTrue(self.mock_command_runner.has_called(cmd="/usr/local/bin/pipenv", args=["run", "pip", "freeze"]))
         self.assertEqual(
             files_to_commit,
             [
@@ -48,17 +46,15 @@ class TestPipenvUpdate(BasePackageManagerTest):
         # Ensure pipenv upgrade is NOT called for transitive dependencies
         self.assertFalse(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/pipenv", args=["upgrade", "--ignore-pipfile", "package1==2.0.0"]
+                cmd="/usr/local/bin/pipenv", args=["upgrade", "--ignore-pipfile", "package1==2.0.0"]
             )
         )
         self.assertEqual(
             toml.dumps({"packages": {"package1": ">=1.0.0", "package2": "~=1.0"}}),
             self.mock_fs.files["/path/to/project/Pipfile"],
         )
-        self.assertTrue(self.mock_command_runner.has_called(cmd="/splat/.local/bin/pipenv", args=["update", "--dev"]))
-        self.assertTrue(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/pipenv", args=["run", "pip", "freeze"])
-        )
+        self.assertTrue(self.mock_command_runner.has_called(cmd="/usr/local/bin/pipenv", args=["update", "--dev"]))
+        self.assertTrue(self.mock_command_runner.has_called(cmd="/usr/local/bin/pipenv", args=["run", "pip", "freeze"]))
         self.assertEqual(
             files_to_commit,
             [

--- a/tests/package_managers/poetry/test_poetry_audit.py
+++ b/tests/package_managers/poetry/test_poetry_audit.py
@@ -20,7 +20,7 @@ class TestPoetryAudit(BasePackageManagerTest):
 
     def test_poetry_audit_installs_dependencies_runs_pip_audit_no_vulns(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_no_vulns, stderr=""),
         )
@@ -29,12 +29,12 @@ class TestPoetryAudit(BasePackageManagerTest):
         # assert
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/poetry", args=["export", "--without-hashes", "--all-groups"]
+                cmd="/usr/local/bin/poetry", args=["export", "--without-hashes", "--all-groups"]
             )
         )
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/poetry",
+                cmd="/usr/local/bin/poetry",
                 args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             )
         )
@@ -42,7 +42,7 @@ class TestPoetryAudit(BasePackageManagerTest):
 
     def test_poetry_audit_runs_pip_audit_returns_vulns(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_with_vulns, stderr=""),
         )
@@ -53,7 +53,7 @@ class TestPoetryAudit(BasePackageManagerTest):
 
     def test_poetry_audit_handles_audit_command_failure(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=2, stdout="", stderr="Audit failed"),
         )
@@ -63,7 +63,7 @@ class TestPoetryAudit(BasePackageManagerTest):
 
     def test_poetry_audit_with_re_audit_skips_install(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/poetry",
+            cmd="/usr/local/bin/poetry",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_no_vulns, stderr=""),
         )
@@ -71,13 +71,13 @@ class TestPoetryAudit(BasePackageManagerTest):
         self.poetry_manager.audit(self.lockfile, re_audit=True)
 
         # Verify that install steps are skipped.
-        self.assertFalse(self.mock_command_runner.has_called(cmd="/splat/.local/bin/poetry", args=["install"]))
+        self.assertFalse(self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["install"]))
         self.assertFalse(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/poetry", args=["add", "pip-audit", "--dev"])
+            self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["add", "pip-audit", "--dev"])
         )
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/poetry",
+                cmd="/usr/local/bin/poetry",
                 args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             )
         )

--- a/tests/package_managers/poetry/test_poetry_update.py
+++ b/tests/package_managers/poetry/test_poetry_update.py
@@ -18,11 +18,9 @@ class TestPoetryUpdate(BasePackageManagerTest):
         files_to_commit = self.poetry_manager.update(vuln_report)
 
         self.assertTrue(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/poetry", args=["add", "package1@^2.0.0"])
+            self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["add", "package1@^2.0.0"])
         )
-        self.assertFalse(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/poetry", args=["lock", "--no-update"])
-        )
+        self.assertFalse(self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["lock", "--no-update"]))
         self.assertEqual(
             files_to_commit,
             [
@@ -38,11 +36,9 @@ class TestPoetryUpdate(BasePackageManagerTest):
         files_to_commit = self.poetry_manager.update(vuln_report)
 
         self.assertTrue(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/poetry", args=["add", "package1@^2.0.0"])
+            self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["add", "package1@^2.0.0"])
         )
-        self.assertTrue(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/poetry", args=["lock", "--no-update"])
-        )
+        self.assertTrue(self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["lock", "--no-update"]))
         self.assertEqual(files_to_commit, [str(vuln_report.lockfile.path)])
 
     def test_update_skips_when_fixed_version_is_none(self) -> None:

--- a/tests/package_managers/uv/test_uv_audit.py
+++ b/tests/package_managers/uv/test_uv_audit.py
@@ -17,7 +17,7 @@ class TestUvAudit(BasePackageManagerTest):
 
     def test_uv_audit_installs_dependencies_runs_pip_audit_no_vulns(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/uv",
+            cmd="/usr/local/bin/uv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_no_vulns, stderr=""),
         )
@@ -26,20 +26,20 @@ class TestUvAudit(BasePackageManagerTest):
 
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/uv",
+                cmd="/usr/local/bin/uv",
                 args=["export", "--no-emit-project", "--dev", "--no-hashes", "-o", "requirements.txt"],
             )
         )
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/uv", args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"]
+                cmd="/usr/local/bin/uv", args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"]
             )
         )
         self.assertEqual(result, [])
 
     def test_poetry_audit_runs_pip_audit_returns_vulns(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/uv",
+            cmd="/usr/local/bin/uv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_with_vulns, stderr=""),
         )
@@ -59,7 +59,7 @@ class TestUvAudit(BasePackageManagerTest):
 
     def test_uv_audit_with_re_audit_skips_install(self) -> None:
         self.mock_command_runner.set_response(
-            cmd="/splat/.local/bin/uv",
+            cmd="/usr/local/bin/uv",
             args=["run", "pip-audit", "-r", "requirements.txt", "--fix", "-f", "json"],
             response=CommandResult(exit_code=0, stdout=self.mock_pip_audit_out_no_vulns, stderr=""),
         )
@@ -67,9 +67,9 @@ class TestUvAudit(BasePackageManagerTest):
         self.uv_manager.audit(self.lockfile, re_audit=True)
 
         # Verify that install steps are skipped.
-        self.assertFalse(self.mock_command_runner.has_called(cmd="/splat/.local/bin/uv", args=["install"]))
+        self.assertFalse(self.mock_command_runner.has_called(cmd="/usr/local/bin/uv", args=["install"]))
         self.assertFalse(
-            self.mock_command_runner.has_called(cmd="/splat/.local/bin/uv", args=["add", "pip-audit", "--dev"])
+            self.mock_command_runner.has_called(cmd="/usr/local/bin/uv", args=["add", "pip-audit", "--dev"])
         )
 
 

--- a/tests/package_managers/uv/test_uv_update.py
+++ b/tests/package_managers/uv/test_uv_update.py
@@ -16,7 +16,7 @@ class TestUvUpdate(BasePackageManagerTest):
         files_to_commit = self.uv_manager.update(vuln_report)
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/uv",
+                cmd="/usr/local/bin/uv",
                 args=["add", "package1~=2.0.0"],
             )
         )
@@ -37,7 +37,7 @@ class TestUvUpdate(BasePackageManagerTest):
         self.assertEqual(files_to_commit, [str(vuln_report.lockfile.path)])
         self.assertTrue(
             self.mock_command_runner.has_called(
-                cmd="/splat/.local/bin/uv",
+                cmd="/usr/local/bin/uv",
                 args=["lock", "--upgrade-package", "package1~=2.0.0"],
             )
         )

--- a/tests/utils/command_runner/test_safe_run.py
+++ b/tests/utils/command_runner/test_safe_run.py
@@ -5,7 +5,7 @@ from splat.utils.command_runner.safe_run import is_command_whitelisted
 
 class TestSubprocessHandler(unittest.TestCase):
     def test_is_command_whitelisted_with_valid_command_and_args(self) -> None:
-        cmd = "/splat/.local/bin/pipenv"  # Bypass type checking with Any
+        cmd = "/usr/local/bin/pipenv"  # Bypass type checking with Any
         args = ["install"]
         result = is_command_whitelisted(cmd, args)
         self.assertTrue(result)
@@ -17,7 +17,7 @@ class TestSubprocessHandler(unittest.TestCase):
         self.assertFalse(result)
 
     def test_is_command_whitelisted_with_invalid_args(self) -> None:
-        cmd = "/splat/.local/bin/pipenv"
+        cmd = "/usr/local/bin/pipenv"
         args = ["invalid", "arg"]
         result = is_command_whitelisted(cmd, args)
         self.assertFalse(result)


### PR DESCRIPTION
When bind-mounting a local Git repository into the Splat Docker container, Splat’s Git operations fail due to ownership and permission mismatches.

errors like:
{{fatal: detected dubious ownership in repository at '/splat/test-drive' }}
fatal: Unable to create '/splat/test-drive/.git/index.lock': Permission denied

Even after whitelisting with safe.directory, the container user still can’t write .git/index.lock.

Environment:

Host: Ubuntu with UID != 1001
Container image: girade/splat:1 (runs as user splatuser UID 1001)
Repository mounted via -v /path/to/repo:/splat/test-drive

Steps to Reproduce:

1. Clone any Git repo on the host owned by your user UID for example 1000. Run id -u to see your host user id.
2. Run steps from the [Running Splat section ](https://github.com/gira-de/splat?tab=readme-ov-file#running-splat)in splat README