### PR TITLE
fix(git): fix branch checkout logic to avoid checkout ambiguity

### DIFF
--- a/splat/package_managers/poetry/command_runner.py
+++ b/splat/package_managers/poetry/command_runner.py
@@ -65,7 +65,7 @@ class PoetryCommandRunner:
     def lock(self, cwd: Path) -> None:
         result = self.runner.run(
             cmd="/usr/local/bin/poetry",
-            args=["lock", "--no-update"],
+            args=["lock"],
             cwd=cwd,
         )
         self.logger.debug(result.stdout)

--- a/splat/source_control/github/GithubPlatform.py
+++ b/splat/source_control/github/GithubPlatform.py
@@ -156,7 +156,7 @@ class GithubPlatform(GitPlatformInterface):
 
             matching_pr = self.pr_handler.find_matching_pr(project, title, timeout)
 
-            if matching_pr:
+            if matching_pr and matching_pr.body:
                 new_pr_description = self.description_updater.update_existing_description(
                     matching_pr.body,
                     new_commit_messages_part,

--- a/splat/source_control/github/model.py
+++ b/splat/source_control/github/model.py
@@ -21,7 +21,7 @@ class HeadGithubPullRequestEntry(BaseModel, extra="allow"):
 
 class GithubPullRequestEntry(BaseModel, extra="allow"):
     title: str
-    body: str
+    body: str | None
     url: str
     html_url: str
     head: HeadGithubPullRequestEntry

--- a/splat/utils/git_operations.py
+++ b/splat/utils/git_operations.py
@@ -60,7 +60,6 @@ def checkout_branch(repo_path: Path, branch_name: str, is_local_project: bool = 
         if branch_exists is True:
             repo.git.switch(branch_name)
             if is_local_project is False:
-                repo.git.checkout(branch_name)
                 repo.remote().pull(branch_name)
                 logger.info(
                     f"Checked out and pulled from existing remote branch '{branch_name}' "

--- a/splat/utils/git_operations.py
+++ b/splat/utils/git_operations.py
@@ -58,7 +58,7 @@ def checkout_branch(repo_path: Path, branch_name: str, is_local_project: bool = 
         branch_exists = branch_name in (repo.heads if is_local_project else repo.remote().refs)
 
         if branch_exists is True:
-            repo.git.checkout(branch_name)
+            repo.git.switch(branch_name)
             if is_local_project is False:
                 repo.git.checkout(branch_name)
                 repo.remote().pull(branch_name)

--- a/splat/utils/git_operations.py
+++ b/splat/utils/git_operations.py
@@ -52,8 +52,9 @@ def checkout_branch(repo_path: Path, branch_name: str, is_local_project: bool = 
     """Checks out the specified branch if it exists, or creates it if it does not."""
     try:
         repo = Repo(repo_path, search_parent_directories=True)
-        main_branch_name = repo.git.symbolic_ref("refs/remotes/origin/HEAD").split("/")[-1]
-        logger.debug(f"Checking out branch '{main_branch_name}' to '{branch_name}' in repository '{repo_path.name}'")
+        # determine default branch
+        default_branch = repo.git.symbolic_ref("refs/remotes/origin/HEAD").split("/")[-1]
+        logger.debug(f"Checking out branch '{default_branch}' to '{branch_name}' in repository '{repo_path.name}'")
 
         branch_exists = branch_name in (repo.heads if is_local_project else repo.remote().refs)
 
@@ -63,18 +64,18 @@ def checkout_branch(repo_path: Path, branch_name: str, is_local_project: bool = 
                 repo.remote().pull(branch_name)
                 logger.info(
                     f"Checked out and pulled from existing remote branch '{branch_name}' "
-                    f"in repository '{repo_path.name}' (default branch: '{main_branch_name}')"
+                    f"in repository '{repo_path.name}' (default branch: '{default_branch}')"
                 )
             else:
                 logger.info(
                     f"Checked out existing local branch '{branch_name}' in repository '{repo_path.name}' "
-                    f"(default branch: '{main_branch_name}')"
+                    f"(default branch: '{default_branch}')"
                 )
         else:
             repo.git.checkout("HEAD", b=branch_name)
             logger.info(
                 f"Created and checked out new branch '{branch_name}' in repository '{repo_path.name}' "
-                f"(from default branch: '{main_branch_name}')"
+                f"(from default branch: '{default_branch}')"
             )
     except Exception as e:
         logger.error(f"Failed to checkout, pull, or create branch '{branch_name}' in repository '{repo_path}': {e}")

--- a/tests/package_managers/poetry/test_poetry_update.py
+++ b/tests/package_managers/poetry/test_poetry_update.py
@@ -38,7 +38,7 @@ class TestPoetryUpdate(BasePackageManagerTest):
         self.assertTrue(
             self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["add", "package1@^2.0.0"])
         )
-        self.assertTrue(self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["lock", "--no-update"]))
+        self.assertTrue(self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["lock"]))
         self.assertEqual(files_to_commit, [str(vuln_report.lockfile.path)])
 
     def test_update_skips_when_fixed_version_is_none(self) -> None:

--- a/tests/utils/test_checkout_branch.py
+++ b/tests/utils/test_checkout_branch.py
@@ -25,7 +25,7 @@ class TestCheckoutBranch(unittest.TestCase):
         checkout_branch(repo_path, branch_name, is_local_project=False)
 
         # Assert that the branch was checked out and pulled
-        mock_git.checkout.assert_any_call(branch_name)
+        mock_git.switch.assert_any_call(branch_name)
         mock_remote.pull.assert_called_once_with(branch_name)
 
         # Check the correct log message with the mocked branch name
@@ -49,7 +49,7 @@ class TestCheckoutBranch(unittest.TestCase):
         checkout_branch(repo_path, branch_name, is_local_project=True)
 
         # Assert that the branch was checked out
-        mock_git.checkout.assert_called_once_with(branch_name)
+        mock_git.switch.assert_called_once_with(branch_name)
         mock_logger.info.assert_called_with(
             f"Checked out existing local branch '{branch_name}' in repository '{repo_path.name}' "
             f"(default branch: 'HEAD')"


### PR DESCRIPTION
- Use git switch instead of git checkout to prevent ambiguity and be explicit. 