### PR TITLE
Refactor poetry update transitive dependency

### DIFF
--- a/splat/package_managers/poetry/PoetryPackageManager.py
+++ b/splat/package_managers/poetry/PoetryPackageManager.py
@@ -14,7 +14,6 @@ from splat.package_managers.poetry.repo_manager import PoetryRepoManager
 from splat.utils.command_runner.interface import CommandRunner
 from splat.utils.env_manager.interface import EnvManager
 from splat.utils.fs import FileSystemInterface
-from splat.utils.git_operations import discard_files_changes
 
 
 class PoetryPackageManager(PackageManagerInterface):
@@ -90,7 +89,11 @@ class PoetryPackageManager(PackageManagerInterface):
                     cwd=vuln_report.lockfile.path.parent,
                     is_dev=vuln_report.dep.is_dev,
                 )
-                discard_files_changes(vuln_report.lockfile.path.parent, [str(pyproject_file_path)])
+                self.pyproject_manager.remove_dependency(
+                    pyproject_path=str(pyproject_file_path),
+                    dependency_name=vuln_report.dep.name,
+                    is_dev=vuln_report.dep.is_dev,
+                )
                 self.poetry.lock(vuln_report.lockfile.path.parent)
                 self.logger.info(f"Successfully updated sub-dependency: {init_log_msg}")
             else:

--- a/tests/package_managers/poetry/pyproject_manager/test_remove_dependency.py
+++ b/tests/package_managers/poetry/pyproject_manager/test_remove_dependency.py
@@ -1,0 +1,59 @@
+import unittest
+
+import tomlkit
+
+from splat.package_managers.poetry.pyproject_manager import PoetryPyprojectManager
+from tests.mocks import MockFileSystem, MockLogger
+
+
+class TestPoetryRemoveDependency(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_fs = MockFileSystem()
+        self.mock_logger = MockLogger()
+        self.manager = PoetryPyprojectManager(self.mock_fs, self.mock_logger)
+        self.path = "/project/pyproject.toml"
+
+    def test_when_regular_dependency_exists_removes_it_and_keeps_other_dependencies(self) -> None:
+        content = """
+        [tool.poetry]
+        name = "demo"
+        [tool.poetry.dependencies]
+        python = ">=3.11"
+        dep1 = "0.100.0"
+        dep2 = "1.2.0"
+        """
+        self.mock_fs.write(self.path, content)
+        removed = self.manager.remove_dependency(self.path, "dep2", is_dev=False)
+        self.assertTrue(removed)
+        updated = tomlkit.parse(self.mock_fs.read(self.path))
+        deps = updated.get("tool", None).get("poetry").get("dependencies")
+        self.assertNotIn("dep2", deps)
+        self.assertIn("dep1", deps)
+
+    def test_when_dev_dependency_exists_removes_it_and_keeps_other_dependencies(self) -> None:
+        content = """
+        [tool.poetry]
+        name = "demo"
+        [tool.poetry.group.dev.dependencies]
+        dep1 = "^7.4"
+        dep2 = "^24.0"
+        """
+        self.mock_fs.write(self.path, content)
+        removed = self.manager.remove_dependency(self.path, "dep2", is_dev=True)
+        self.assertTrue(removed)
+        updated = tomlkit.parse(self.mock_fs.read(self.path))
+        dev_deps = updated.get("tool", None).get("poetry").get("group").get("dev").get("dependencies")
+        self.assertNotIn("dep2", dev_deps)
+        self.assertIn("dep1", dev_deps)
+
+    def test_when_dependency_missing_returns_false_and_does_not_modify_file(self) -> None:
+        content = """
+        [tool.poetry]
+        name = "demo"
+        [tool.poetry.dependencies]
+        python = ">=3.11"
+        """
+        self.mock_fs.write(self.path, content)
+        removed = self.manager.remove_dependency(self.path, "fastapi", is_dev=False)
+        self.assertFalse(removed)
+        self.assertEqual(self.mock_fs.read(self.path), content)

--- a/tests/package_managers/poetry/test_poetry_update.py
+++ b/tests/package_managers/poetry/test_poetry_update.py
@@ -1,5 +1,7 @@
 import unittest
 
+import toml
+
 from splat.model import DependencyType
 from splat.package_managers.poetry.PoetryPackageManager import PoetryPackageManager
 from tests.package_managers.base_test import BasePackageManagerTest
@@ -32,6 +34,10 @@ class TestPoetryUpdate(BasePackageManagerTest):
     def test_update_transitive_dependency(self) -> None:
         vuln_report = self.audit_report
         vuln_report.dep.type = DependencyType.TRANSITIVE
+        mock_pyproject_content = toml.dumps(
+            {"tool": {"poetry": {"dependencies": {"package1": "^1.0.0", "package2": "^1.0.0"}}}}
+        )
+        self.mock_fs.write("/path/to/project/pyproject.toml", mock_pyproject_content)
 
         files_to_commit = self.poetry_manager.update(vuln_report)
 


### PR DESCRIPTION
**Motivation**

- We currently update transitive dependencies in projects managed by Poetry by adding them as direct dependencies in pyproject.toml, then relying on git file-discard operations and a poetry lock --no-update invocation. While this works, it mixed unrelated concerns: dependency resolution logic (Poetry) and version-control cleanup (Git).
To improve this, we are moving to instead of relying on git discard files, we now explicitly remove the dependency from pyproject.toml using the existing PoetryPyprojectManager.

**To-do**
- Transitive dependency updates use explicit TOML manipulation (PoetryPyprojectManager.remove_dependency) instead of git-based discard mechanisms.
- Unit tests for remove_dependency
