### PR TITLE
Splat Dependency Updates

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -551,14 +551,14 @@ files = [
 
 [[package]]
 name = "pip"
-version = "25.1.1"
+version = "25.3"
 description = "The PyPA recommended tool for installing Python packages."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pip-25.1.1-py3-none-any.whl", hash = "sha256:2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af"},
-    {file = "pip-25.1.1.tar.gz", hash = "sha256:3de45d411d308d5054c2168185d8da7f9a2cd753dbac8acbfa88a8909ecd9077"},
+    {file = "pip-25.3-py3-none-any.whl", hash = "sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd"},
+    {file = "pip-25.3.tar.gz", hash = "sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -254,20 +254,15 @@ files = [
 
 [[package]]
 name = "filelock"
-version = "3.18.0"
+version = "3.20.2"
 description = "A platform independent file lock."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de"},
-    {file = "filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2"},
+    {file = "filelock-3.20.2-py3-none-any.whl", hash = "sha256:fbba7237d6ea277175a32c54bb71ef814a8546d8601269e1bfc388de333974e8"},
+    {file = "filelock-3.20.2.tar.gz", hash = "sha256:a2241ff4ddde2a7cebddf78e39832509cb045d18ec1a09d7248d6bfc6bfbbe64"},
 ]
-
-[package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)", "pytest (>=8.3.4)", "pytest-asyncio (>=0.25.2)", "pytest-cov (>=6)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.28.1)"]
-typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "gitdb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1073,21 +1073,21 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
+    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+brotli = ["brotli (>=1.2.0)", "brotlicffi (>=1.2.0.0)"]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0)"]
 
 [metadata]
 lock-version = "2.1"


### PR DESCRIPTION
Automated pull request generated by Splat.

**Updates Summary:**
<details>
<summary>fix: Security: Update urllib3 from 2.5.0 to 2.6.0 in /poetry.lock</summary>


This update addresses the following vulnerabilities:

- ## Impact  
urllib3 supports chained HTTP encoding algorithms for response content according to RFC 9110 (e.g., `Content-Encoding: gzip, zstd`).  However, the number of links in the decompression chain was unbounded allowing a malicious server to insert a virtually unlimited number of compression steps leading to high CPU usage and massive memory allocation for the decompressed data.   ## Affected usages  Applications and libraries using urllib3 version 2.5.0 and earlier for HTTP requests to untrusted sources unless they disable content decoding explicitly.   ## Remediation  Upgrade to at least urllib3 v2.6.0 in which the library limits the number of links to 5.  If upgrading is not immediately possible, use [`preload_content=False`](https://urllib3.readthedocs.io/en/2.5.0/advanced-usage.html#streaming-and-i-o) and ensure that `resp.headers["content-encoding"]` contains a safe number of encodings before reading the response content.
  - Aliases: CVE-2025-66418
  - Recommendation: 2.6.0

- ### Impact  
urllib3's [streaming API](https://urllib3.readthedocs.io/en/2.5.0/advanced-usage.html#streaming-and-i-o) is designed for the efficient handling of large HTTP responses by reading the content in chunks, rather than loading the entire response body into memory at once.  When streaming a compressed response, urllib3 can perform decoding or decompression based on the HTTP `Content-Encoding` header (e.g., `gzip`, `deflate`, `br`, or `zstd`). The library must read compressed data from the network and decompress it until the requested chunk size is met. Any resulting decompressed data that exceeds the requested amount is held in an internal buffer for the next read operation.  The decompression logic could cause urllib3 to fully decode a small amount of highly compressed data in a single operation. This can result in excessive resource consumption (high CPU usage and massive memory allocation for the decompressed data; CWE-409) on the client side, even if the application only requested a small chunk of data.   ### Affected usages  Applications and libraries using urllib3 version 2.5.0 and earlier to stream large compressed responses or content from untrusted sources.  `stream()`, `read(amt=256)`, `read1(amt=256)`, `read_chunked(amt=256)`, `readinto(b)` are examples of `urllib3.HTTPResponse` method calls using the affected logic unless decoding is disabled explicitly.   ### Remediation  Upgrade to at least urllib3 v2.6.0 in which the library avoids decompressing data that exceeds the requested amount.  If your environment contains a package facilitating the Brotli encoding, upgrade to at least Brotli 1.2.0 or brotlicffi 1.2.0.0 too. These versions are enforced by the `urllib3[brotli]` extra in the patched versions of urllib3.   ### Credits  The issue was reported by @Cycloctane. Supplemental information was provided by @stamparm during a security audit performed by [7ASecurity](https://7asecurity.com/) and facilitated by [OSTIF](https://ostif.org/).
  - Aliases: CVE-2025-66471
  - Recommendation: 2.6.0


</details>

<details>
<summary>fix: Security: Update pip from 25.1.1 to 25.3 in /poetry.lock</summary>


This update addresses the following vulnerabilities:

- When extracting a tar archive pip may not check symbolic links point into the extraction directory if the tarfile module doesn't implement PEP 706. Note that upgrading pip to a "fixed" version for this vulnerability doesn't fix all known vulnerabilities that are remediated by using a Python version that implements PEP 706. Note that this is a vulnerability in pip's fallback implementation of tar extraction for Python versions that don't implement PEP 706 and therefore are not secure to all vulnerabilities in the Python 'tarfile' module. If you're using a Python version that implements PEP 706 then pip doesn't use the "vulnerable" fallback code. Mitigations include upgrading to a version of pip that includes the fix, upgrading to a Python version that implements PEP 706 (Python >=3.9.17, >=3.10.12, >=3.11.4, or >=3.12), applying the linked patch, or inspecting source distributions (sdists) before installation as is already a best-practice.
  - Aliases: CVE-2025-8869
  - Recommendation: 25.3


</details>

<details>
<summary>fix: Security: Update filelock from 3.18.0 to 3.20.1 in /poetry.lock</summary>


This update addresses the following vulnerabilities:

- ### Impact  
A Time-of-Check-Time-of-Use (TOCTOU) race condition allows local attackers to corrupt or truncate arbitrary user files through symlink attacks. The vulnerability exists in both Unix and Windows lock file creation where filelock checks if a file exists before opening it with O_TRUNC. An attacker can create a symlink pointing to a victim file in the time gap between the check and open, causing os.open() to follow the symlink and truncate the target file.  **Who is impacted:**  All users of filelock on Unix, Linux, macOS, and Windows systems. The vulnerability cascades to dependent libraries:  - **virtualenv users**: Configuration files can be overwritten with virtualenv metadata, leaking sensitive paths - **PyTorch users**: CPU ISA cache or model checkpoints can be corrupted, causing crashes or ML pipeline failures - **poetry/tox users**: through using virtualenv or filelock on their own.  Attack requires local filesystem access and ability to create symlinks (standard user permissions on Unix; Developer Mode on Windows 10+). Exploitation succeeds within 1-3 attempts when lock file paths are predictable.  ### Patches  Fixed in version **3.20.1**.  **Unix/Linux/macOS fix:** Added O_NOFOLLOW flag to os.open() in UnixFileLock.\_acquire() to prevent symlink following.  **Windows fix:** Added GetFileAttributesW API check to detect reparse points (symlinks/junctions) before opening files in WindowsFileLock.\_acquire().  **Users should upgrade to filelock 3.20.1 or later immediately.**  ### Workarounds  If immediate upgrade is not possible:  1. Use SoftFileLock instead of UnixFileLock/WindowsFileLock (note: different locking semantics, may not be suitable for all use cases) 2. Ensure lock file directories have restrictive permissions (chmod 0700) to prevent untrusted users from creating symlinks 3. Monitor lock file directories for suspicious symlinks before running trusted applications  **Warning:** These workarounds provide only partial mitigation. The race condition remains exploitable. Upgrading to version 3.20.1 is strongly recommended.  ______________________________________________________________________  
## Technical Details: 
How the Exploit Works  ### The Vulnerable Code Pattern  **Unix/Linux/macOS** (`src/filelock/_unix.py:39-44`):  ```python def _acquire(self) -> None:     ensure_directory_exists(self.lock_file)     open_flags = os.O_RDWR | os.O_TRUNC  # (1) Prepare to truncate     if not Path(self.lock_file).exists():  # (2) CHECK: Does file exist?         open_flags |= os.O_CREAT     fd = os.open(self.lock_file, open_flags, ...)  # (3) USE: Open and truncate ```  **Windows** (`src/filelock/_windows.py:19-28`):  ```python def _acquire(self) -> None:     raise_on_not_writable_file(self.lock_file)  # (1) Check writability     ensure_directory_exists(self.lock_file)     flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC  # (2) Prepare to truncate     fd = os.open(self.lock_file, flags, ...)  # (3) Open and truncate ```  ### The Race Window  The vulnerability exists in the gap between operations:  **Unix variant:**  ``` Time    Victim Thread                          Attacker Thread ----    -------------                          --------------- T0      Check: lock_file exists? → False T1                                             ↓ RACE WINDOW T2                                             Create symlink: lock → victim_file T3      Open lock_file with O_TRUNC         → Follows symlink         → Opens victim_file         → Truncates victim_file to 0 bytes! ☠️ ```  **Windows variant:**  ``` Time    Victim Thread                          Attacker Thread ----    -------------                          --------------- T0      Check: lock_file writable? T1                                             ↓ RACE WINDOW T2                                             Create symlink: lock → victim_file T3      Open lock_file with O_TRUNC         → Follows symlink/junction         → Opens victim_file         → Truncates victim_file to 0 bytes! ☠️ ```  ### Step-by-Step Attack Flow  **1. Attacker Setup:**  ```python # Attacker identifies target application using filelock lock_path = "/tmp/myapp.lock"  # Predictable lock path victim_file = "/home/victim/.ssh/config"  # High-value target ```  **2. Attacker Creates Race Condition:**  ```python import os import threading   def attacker_thread():     # Remove any existing lock file     try:         os.unlink(lock_path)     except FileNotFoundError:         pass      # Create symlink pointing to victim file     os.symlink(victim_file, lock_path)     print(f"[Attacker] Created: {lock_path} → {victim_file}")   # Launch attack threading.Thread(target=attacker_thread).start() ```  **3. Victim Application Runs:**  ```python from filelock import UnixFileLock  # Normal application code lock = UnixFileLock("/tmp/myapp.lock") lock.acquire()  # ← VULNERABILITY TRIGGERED HERE # At this point, /home/victim/.ssh/config is now 0 bytes! ```  **4. What Happens Inside os.open():**  On Unix systems, when `os.open()` is called:  ```c // Linux kernel behavior (simplified) int open(const char *pathname, int flags) {     struct file *f = path_lookup(pathname);  // Resolves symlinks by default!      if (flags & O_TRUNC) {         truncate_file(f);  // ← Truncates the TARGET of the symlink     }      return file_descriptor; } ```  Without `O_NOFOLLOW` flag, the kernel follows the symlink and truncates the target file.  ### Why the Attack Succeeds Reliably  **Timing Characteristics:**  - **Check operation** (Path.exists()): ~100-500 nanoseconds - **Symlink creation** (os.symlink()): ~1-10 microseconds - **Race window**: ~1-5 microseconds (very small but exploitable) - **Thread scheduling quantum**: ~1-10 milliseconds  **Success factors:**  1. **Tight loop**: Running attack in a loop hits the race window within 1-3 attempts 2. **CPU scheduling**: Modern OS thread schedulers frequently context-switch during I/O operations 3. **No synchronization**: No atomic file creation prevents the race 4. **Symlink speed**: Creating symlinks is extremely fast (metadata-only operation)  ### Real-World Attack Scenarios  **Scenario 1: virtualenv Exploitation**  ```python # Victim runs: python -m venv /tmp/myenv # Attacker racing to create: os.symlink("/home/victim/.bashrc", "/tmp/myenv/pyvenv.cfg")  # Result: /home/victim/.bashrc overwritten with: # home = /usr/bin/python3 # include-system-site-packages = false # version = 3.11.2 # ← Original .bashrc contents LOST + virtualenv metadata LEAKED to attacker ```  **Scenario 2: PyTorch Cache Poisoning**  ```python # Victim runs: import torch # PyTorch checks CPU capabilities, uses filelock on cache # Attacker racing to create: os.symlink("/home/victim/.torch/compiled_model.pt", "/home/victim/.cache/torch/cpu_isa_check.lock")  # Result: Trained ML model checkpoint truncated to 0 bytes # Impact: Weeks of training lost, ML pipeline DoS ```  ### Why Standard Defenses Don't Help  **File permissions don't prevent this:**  - Attacker doesn't need write access to victim_file - os.open() with O_TRUNC follows symlinks using the *victim's* permissions - The victim process truncates its own file  **Directory permissions help but aren't always feasible:**  - Lock files often created in shared /tmp directory (mode 1777) - Applications may not control lock file location - Many apps use predictable paths in user-writable directories  **File locking doesn't prevent this:**  - The truncation happens *during* the open() call, before any lock is acquired - fcntl.flock() only prevents concurrent lock acquisition, not symlink attacks  ### Exploitation Proof-of-Concept Results  From empirical testing with the provided PoCs:  **Simple Direct Attack** (`filelock_simple_poc.py`):  - Success rate: 33% per attempt (1 in 3 tries) - Average attempts to success: 2.1 - Target file reduced to 0 bytes in \<100ms  **virtualenv Attack** (`weaponized_virtualenv.py`):  - Success rate: ~90% on first attempt (deterministic timing) - Information leaked: File paths, Python version, system configuration - Data corruption: Complete loss of original file contents  **PyTorch Attack** (`weaponized_pytorch.py`):  - Success rate: 25-40% per attempt - Impact: Application crashes, model loading failures - Recovery: Requires cache rebuild or model retraining  **Discovered and reported by:** George Tsigourakos (@tsigouris007)
  - Aliases: CVE-2025-68146
  - Recommendation: 3.20.1


</details>

