### PR TITLE
fix: fix: always commit manifest file for uv and poetry updates (G-941)

### DIFF
--- a/splat/package_managers/poetry/PoetryPackageManager.py
+++ b/splat/package_managers/poetry/PoetryPackageManager.py
@@ -79,7 +79,10 @@ class PoetryPackageManager(PackageManagerInterface):
                 )
 
             pyproject_file_path = vuln_report.lockfile.path.parent / self.manifest_file_name
-            files_to_commit: list[str] = [str(vuln_report.lockfile.path)]
+            files_to_commit: list[str] = [
+                str(vuln_report.lockfile.path),
+                str(pyproject_file_path),
+            ]
 
             if vuln_report.dep.type == DependencyType.TRANSITIVE:
                 self.logger.info(f"Updating sub-dependency: {init_log_msg}")
@@ -104,7 +107,6 @@ class PoetryPackageManager(PackageManagerInterface):
                     cwd=vuln_report.lockfile.path.parent,
                     is_dev=vuln_report.dep.is_dev,
                 )
-                files_to_commit.append(str(pyproject_file_path))
                 self.logger.info(f"Successfully updated dependency: {init_log_msg}")
             return files_to_commit
         except RuntimeError as e:

--- a/splat/package_managers/uv/UvPackageManager.py
+++ b/splat/package_managers/uv/UvPackageManager.py
@@ -64,7 +64,10 @@ class UvPackageManager(PackageManagerInterface):
                 )
 
             pyproject_file_path = vuln_report.lockfile.path.parent / self.manifest_file_name
-            files_to_commit: list[str] = [str(vuln_report.lockfile.path)]
+            files_to_commit: list[str] = [
+                str(vuln_report.lockfile.path),
+                str(pyproject_file_path),
+            ]
 
             if vuln_report.dep.type == DependencyType.TRANSITIVE:
                 self.logger.info(f"Updating sub-dependency: {init_log_msg}")
@@ -83,7 +86,6 @@ class UvPackageManager(PackageManagerInterface):
                     cwd=vuln_report.lockfile.path.parent,
                     is_dev=vuln_report.dep.is_dev,
                 )
-                files_to_commit.append(str(pyproject_file_path))
                 self.logger.info(f"Successfully updated dependency: {init_log_msg}")
             return files_to_commit
         except RuntimeError as e:

--- a/tests/package_managers/poetry/test_poetry_update.py
+++ b/tests/package_managers/poetry/test_poetry_update.py
@@ -45,7 +45,13 @@ class TestPoetryUpdate(BasePackageManagerTest):
             self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["add", "package1@^2.0.0"])
         )
         self.assertTrue(self.mock_command_runner.has_called(cmd="/usr/local/bin/poetry", args=["lock"]))
-        self.assertEqual(files_to_commit, [str(vuln_report.lockfile.path)])
+        self.assertEqual(
+            files_to_commit,
+            [
+                str(vuln_report.lockfile.path),
+                str(vuln_report.lockfile.path.parent / self.poetry_manager.manifest_file_name),
+            ],
+        )
 
     def test_update_skips_when_fixed_version_is_none(self) -> None:
         vuln_report = self.audit_report

--- a/tests/package_managers/uv/test_uv_update.py
+++ b/tests/package_managers/uv/test_uv_update.py
@@ -34,7 +34,13 @@ class TestUvUpdate(BasePackageManagerTest):
 
         files_to_commit = self.uv_manager.update(vuln_report)
 
-        self.assertEqual(files_to_commit, [str(vuln_report.lockfile.path)])
+        self.assertEqual(
+            files_to_commit,
+            [
+                str(vuln_report.lockfile.path),
+                str(vuln_report.lockfile.path.parent / self.uv_manager.manifest_file_name),
+            ],
+        )
         self.assertTrue(
             self.mock_command_runner.has_called(
                 cmd="/usr/local/bin/uv",


### PR DESCRIPTION
Ensure pyproject.toml is always committed alongside uv/poetry lockfile changes (including transitive updates and pip-audit installation) so the manifest and lockfile never drift out of sync.